### PR TITLE
Added namespace variable for Servicemonitor object

### DIFF
--- a/helm/values/mysqldb/values.yaml
+++ b/helm/values/mysqldb/values.yaml
@@ -1217,7 +1217,7 @@ metrics:
     enabled: true
     ## @param metrics.serviceMonitor.namespace Specify the namespace in which the serviceMonitor resource will be created
     ##
-    namespace: "monitoring"
+    namespace: "${service_monitor_namespace}"
     ## @param metrics.serviceMonitor.jobLabel The name of the label on the target service to use as the job name in prometheus.
     ##
     jobLabel: ""

--- a/main.tf
+++ b/main.tf
@@ -81,6 +81,7 @@ resource "helm_release" "mysqldb" {
       replication_password        = random_password.mysqldb_replication_user_password.result,
       mysqldb_root_password       = random_password.mysqldb_root_password.result,
       mysqldb_exporter_enabled    = var.mysqldb_exporter_enabled,
+      service_monitor_namespace   = var.namespace
       metrics_exporter_password   = random_password.mysqldb_exporter_user_password.result,
       secondary_pod_replica_count = var.mysqldb_config.secondary_db_replica_count
     }),


### PR DESCRIPTION
What: Added variables for servicemonitor

Why: The namespace to create servicemonitor was hardcoded hence resources are conflicting if the module is called in Demo modules. 